### PR TITLE
Add custom actions

### DIFF
--- a/.changeset/selfish-tips-prove.md
+++ b/.changeset/selfish-tips-prove.md
@@ -1,0 +1,9 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Added more entry points for UI Hooks in admin ui. Similar to `itemHeaderActions`.
+
+- `listHeaderActions` - this adds button in place of `Create` item button on list page.
+- `listManageActions` - this adds button in place of multi select update on list page (Update Many and Delete Many).
+- `listItemActions` - this adds dropdown buttons for each item in list. caveat: you have to recreate the DropDown component, can be copied from the source.

--- a/packages/app-admin-ui/client/components/ListTable.tsx
+++ b/packages/app-admin-ui/client/components/ListTable.tsx
@@ -154,7 +154,7 @@ class SortLink extends React.Component<SortLinkProps> {
 
 const ItemDropDown = ({ list, item, link, onDelete, ...props }) => {
   const [deleteModalIsVisible, setDeleteModal] = useState(false);
-  let { listItemActions } = useUIHooks();
+  const { listItemActions } = useUIHooks();
 
   const copyText = window.location.origin + link({ path: list.path, item });
 

--- a/packages/app-admin-ui/client/pages/Item/ItemTitle.tsx
+++ b/packages/app-admin-ui/client/pages/Item/ItemTitle.tsx
@@ -54,8 +54,7 @@ const AddNewItem = () => {
 export const ItemTitle = memo(function ItemTitle({ titleText, adminPath }: Props) {
   const { list } = useList();
   const listHref = `${adminPath}/${list.path}`;
-  const uiHooks = useUIHooks();
-  const { itemHeaderActions } = uiHooks;
+  let { itemHeaderActions } = useUIHooks();
   return (
     <HeaderInset>
       <PageTitle>{titleText}</PageTitle>

--- a/packages/app-admin-ui/client/pages/Item/ItemTitle.tsx
+++ b/packages/app-admin-ui/client/pages/Item/ItemTitle.tsx
@@ -54,7 +54,7 @@ const AddNewItem = () => {
 export const ItemTitle = memo(function ItemTitle({ titleText, adminPath }: Props) {
   const { list } = useList();
   const listHref = `${adminPath}/${list.path}`;
-  let { itemHeaderActions } = useUIHooks();
+  const { itemHeaderActions } = useUIHooks();
   return (
     <HeaderInset>
       <PageTitle>{titleText}</PageTitle>

--- a/packages/app-admin-ui/client/pages/List/Management.tsx
+++ b/packages/app-admin-ui/client/pages/List/Management.tsx
@@ -8,6 +8,8 @@ import { FlexGroup } from '@k5ui/layout';
 import { IconButton } from '@k5ui/button';
 import { colors, gridSize } from '@k5ui/theme';
 
+import { useList } from '../../providers/List';
+import { useUIHooks } from '../../providers/Hooks';
 import UpdateManyItemsModal from '../../components/UpdateManyItemsModal';
 import DeleteManyItemsModal from '../../components/DeleteManyItemsModal';
 import List from '../../classes/List';
@@ -23,6 +25,86 @@ const SelectedCount = styled.div({
   marginRight: gridSize,
 });
 
+const UpdateItems = ({ selectedItems, onUpdateMany }) => {
+  const [updateModalIsVisible, setUpdateModal] = useState(false);
+
+  let { list } = useList();
+  if (!list.access.update) return null;
+  const handleUpdate = () => {
+    setUpdateModal(false);
+    onUpdateMany();
+  };
+
+  return (
+    <Fragment>
+      <IconButton
+        appearance="primary"
+        icon={SettingsIcon}
+        onClick={() => setUpdateModal(true)}
+        variant="nuance"
+        data-test-name="update"
+      >
+        Update
+      </IconButton>
+      <UpdateManyItemsModal
+        isOpen={updateModalIsVisible}
+        items={selectedItems}
+        list={list}
+        onClose={() => setUpdateModal(false)}
+        onUpdate={handleUpdate}
+      />
+    </Fragment>
+  );
+};
+
+const DeleteItems = ({ selectedItems, onDeleteMany }: $TSFixMe) => {
+  const [deleteModalIsVisible, setDeleteModal] = useState(false);
+  let { list } = useList();
+
+  if (!list.access.update) return null;
+  const handleDelete = () => {
+    setDeleteModal(false);
+    onDeleteMany();
+  };
+
+  return (
+    <Fragment>
+      <IconButton
+        appearance="danger"
+        icon={TrashcanIcon}
+        onClick={() => setDeleteModal(true)}
+        variant="nuance"
+        data-test-name="delete"
+      >
+        Delete
+      </IconButton>
+      <DeleteManyItemsModal
+        isOpen={deleteModalIsVisible}
+        itemIds={selectedItems}
+        list={list}
+        onClose={() => setDeleteModal(false)}
+        onDelete={handleDelete}
+      />
+    </Fragment>
+  );
+};
+
+const renderActions = ({ ...props }) => {
+  let { listManageActions } = useUIHooks();
+
+  if (!ENABLE_DEV_FEATURES) return null;
+
+  if (listManageActions) {
+    return listManageActions({ ...props, UpdateItems, DeleteItems });
+  }
+  return (
+    <Fragment>
+      <UpdateItems {...props} />
+      <DeleteItems {...props} />
+    </Fragment>
+  );
+};
+
 type Props = {
   list: List;
   onDeleteMany: (x0?: $TSFixMe) => void;
@@ -33,20 +115,9 @@ type Props = {
 };
 
 export default function ListManage(props: Props) {
-  const { onDeleteMany, onUpdateMany, selectedItems } = props;
-  const [deleteModalIsVisible, setDeleteModal] = useState(false);
-  const [updateModalIsVisible, setUpdateModal] = useState(false);
+  const { selectedItems } = props;
 
-  const handleDelete = () => {
-    setDeleteModal(false);
-    onDeleteMany();
-  };
-  const handleUpdate = () => {
-    setUpdateModal(false);
-    onUpdateMany();
-  };
-
-  const { list, pageSize, totalItems } = props;
+  const { pageSize, totalItems } = props;
   const selectedCount = selectedItems.length;
 
   return (
@@ -55,46 +126,8 @@ export default function ListManage(props: Props) {
         <SelectedCount>
           {selectedCount} of {Math.min(pageSize, totalItems)} Selected
         </SelectedCount>
-        {ENABLE_DEV_FEATURES ? (
-          list.access.update ? (
-            <IconButton
-              appearance="primary"
-              icon={SettingsIcon}
-              onClick={() => setUpdateModal(true)}
-              variant="nuance"
-              data-test-name="update"
-            >
-              Update
-            </IconButton>
-          ) : null
-        ) : null}
-        {list.access.update ? (
-          <IconButton
-            appearance="danger"
-            icon={TrashcanIcon}
-            onClick={() => setDeleteModal(true)}
-            variant="nuance"
-            data-test-name="delete"
-          >
-            Delete
-          </IconButton>
-        ) : null}
+        {renderActions({ ...props })}
       </FlexGroup>
-
-      <UpdateManyItemsModal
-        isOpen={updateModalIsVisible}
-        items={selectedItems}
-        list={list}
-        onClose={() => setUpdateModal(false)}
-        onUpdate={handleUpdate}
-      />
-      <DeleteManyItemsModal
-        isOpen={deleteModalIsVisible}
-        itemIds={selectedItems}
-        list={list}
-        onClose={() => setDeleteModal(false)}
-        onDelete={handleDelete}
-      />
     </Fragment>
   );
 }

--- a/packages/app-admin-ui/client/pages/List/Management.tsx
+++ b/packages/app-admin-ui/client/pages/List/Management.tsx
@@ -28,7 +28,7 @@ const SelectedCount = styled.div({
 const UpdateItems = ({ selectedItems, onUpdateMany }) => {
   const [updateModalIsVisible, setUpdateModal] = useState(false);
 
-  let { list } = useList();
+  const { list } = useList();
   if (!list.access.update) return null;
   const handleUpdate = () => {
     setUpdateModal(false);
@@ -59,7 +59,7 @@ const UpdateItems = ({ selectedItems, onUpdateMany }) => {
 
 const DeleteItems = ({ selectedItems, onDeleteMany }: $TSFixMe) => {
   const [deleteModalIsVisible, setDeleteModal] = useState(false);
-  let { list } = useList();
+  const { list } = useList();
 
   if (!list.access.update) return null;
   const handleDelete = () => {
@@ -90,7 +90,8 @@ const DeleteItems = ({ selectedItems, onDeleteMany }: $TSFixMe) => {
 };
 
 const renderActions = ({ ...props }) => {
-  let { listManageActions } = useUIHooks();
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { listManageActions } = useUIHooks();
 
   if (!ENABLE_DEV_FEATURES) return null;
 

--- a/packages/app-admin-ui/client/pages/List/index.tsx
+++ b/packages/app-admin-ui/client/pages/List/index.tsx
@@ -3,8 +3,6 @@
 import { jsx } from '@emotion/core';
 import { Fragment, useEffect, useRef, Suspense } from 'react';
 import { useQuery } from '@apollo/react-hooks';
-import { useList } from '../../providers/List';
-
 import { IconButton } from '@k5ui/button';
 import { PlusIcon } from '@k5ui/icons';
 import { Container, FlexGroup } from '@k5ui/layout';
@@ -22,7 +20,6 @@ import DocTitle from '../../components/DocTitle';
 import ListTable from '../../components/ListTable';
 import PageError from '../../components/PageError';
 import { DisclosureArrow } from '../../components/Popout';
-
 import ColumnPopout from './ColumnSelect';
 import ActiveFilters from './Filters/ActiveFilters';
 import SortPopout from './SortSelect';
@@ -31,26 +28,48 @@ import Search from './Search';
 import Management, { ManageToolbar } from './Management';
 import { useListFilter, useListSelect, useListSort, useListUrlState } from './dataHooks';
 import ListType from '../../classes/List';
+import { useList } from '../../providers/List';
+import { useUIHooks } from '../../providers/Hooks';
 
 const HeaderInset = props => (
   <div css={{ paddingLeft: gridSize * 2, paddingRight: gridSize * 2 }} {...props} />
 );
 
+const CreateItem = () => {
+  let {
+    list: { access },
+    openCreateItemModal,
+  } = useList();
+  if (!access.create) return null;
+  const cypressCreateId = 'list-page-create-button';
+  return (
+    <IconButton
+      appearance="primary"
+      icon={PlusIcon}
+      onClick={openCreateItemModal}
+      id={cypressCreateId}
+    >
+      Create
+    </IconButton>
+  );
+};
+
 type Props = {
-  adminMeta: object;
+  adminMeta: $TSFixMe;
   list: ListType;
-  routeProps: object;
+  routeProps: $TSFixMe;
 };
 type LayoutProps = Props & {
   items: object[];
   itemCount: number;
   queryErrors: object[];
+  query: $TSFixMe;
 };
 
 export function ListLayout(props: LayoutProps) {
   const { adminMeta, items, itemCount, queryErrors, routeProps, query } = props;
   const measureElementRef = useRef();
-  const { list, openCreateItemModal } = useList();
+  const { list } = useList();
   const { urlState } = useListUrlState(list.key);
   const { filters } = useListFilter(list.key);
   const [sortBy, handleSortChange] = useListSort(list.key);
@@ -60,6 +79,8 @@ export function ListLayout(props: LayoutProps) {
   const { currentPage, fields, pageSize, search } = urlState;
 
   const [selectedItems, onSelectChange] = useListSelect(items);
+
+  let { listHeaderActions } = useUIHooks();
 
   // Mount with Persisted Search
   // ------------------------------
@@ -101,7 +122,6 @@ export function ListLayout(props: LayoutProps) {
   // Success
   // ------------------------------
 
-  const cypressCreateId = 'list-page-create-button';
   const cypressFiltersId = 'ks-list-active-filters';
 
   const Render = ({ children }) => children();
@@ -113,16 +133,7 @@ export function ListLayout(props: LayoutProps) {
         <HeaderInset>
           <FlexGroup align="center" justify="space-between">
             <PageTitle>{list.plural}</PageTitle>
-            {list.access.create ? (
-              <IconButton
-                appearance="primary"
-                icon={PlusIcon}
-                onClick={openCreateItemModal}
-                id={cypressCreateId}
-              >
-                Create
-              </IconButton>
-            ) : null}
+            {listHeaderActions ? listHeaderActions({ CreateItem }) : <CreateItem />}
           </FlexGroup>
           <div
             css={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap' }}

--- a/packages/app-admin-ui/client/pages/List/index.tsx
+++ b/packages/app-admin-ui/client/pages/List/index.tsx
@@ -36,7 +36,7 @@ const HeaderInset = props => (
 );
 
 const CreateItem = () => {
-  let {
+  const {
     list: { access },
     openCreateItemModal,
   } = useList();
@@ -80,7 +80,7 @@ export function ListLayout(props: LayoutProps) {
 
   const [selectedItems, onSelectChange] = useListSelect(items);
 
-  let { listHeaderActions } = useUIHooks();
+  const { listHeaderActions } = useUIHooks();
 
   // Mount with Persisted Search
   // ------------------------------


### PR DESCRIPTION
add custom actions from https://github.com/keystonejs/keystone/pull/2469

adding more hooks like `itemHeaderActions` in https://github.com/keystonejs/keystone/pull/2279


- `listHeaderActions` - this adds button in place of `Create` item button on list page.
![image](https://user-images.githubusercontent.com/5769869/71514017-dcb77b00-28c2-11ea-9504-e338b1d6c74b.png)
- `listManageActions` - this adds button in place of multi select update on list page (Update Many and Delete Many).
![image](https://user-images.githubusercontent.com/5769869/71514209-9ca4c800-28c3-11ea-86f8-3814d5ea58c7.png)
- `listItemActions` - this adds dropdown buttons for each item in list. caveat: you have to recreate the DropDown component, can be copied from the source.
![image](https://user-images.githubusercontent.com/5769869/71514113-2f913280-28c3-11ea-9cb3-c06ee6ee053e.png)


All of the above is composable from the existing components on page. the react component should accept the components as props and render them if they want to keep the original component.

